### PR TITLE
Compare servce with all string

### DIFF
--- a/src/installed_services_downloader.py
+++ b/src/installed_services_downloader.py
@@ -112,19 +112,6 @@ class InstalledServicesDownloader:
                 if "\n" in line:
                     line = line[:-1]
                 key, value = line.split("=")
-
-                if value == "true":
-                    value = True
-                elif value == "false":
-                    value = False
-                elif value.isdigit():
-                    value = int(value)
-                else:
-                    try:
-                        value = float(value)
-                    except:
-                        pass
-
                 envs[key] = value
             return envs
         except:


### PR DESCRIPTION
When comparing the remote service and the local service, don't transform values to boolean, float and others.
The comparison is done with the strings bacause the remote saves strings.