### PR TITLE
Change env to envs

### DIFF
--- a/src/installed_services_downloader.py
+++ b/src/installed_services_downloader.py
@@ -142,12 +142,12 @@ class InstalledServicesDownloader:
             logger.warn(f"Invalid remote serivce {service_snapshot.id}")
             raise InvalidRemoteService
 
-        env = service_dict.get("env")
-        if env is None:
+        envs = service_dict.get("envs")
+        if envs is None:
             logger.warn(f"Invalid remote serivce {service_snapshot.id}")
             raise InvalidRemoteService
 
-        return env
+        return envs
 
     def _get_remote_compose(
         self, service_name: str, service_snapshot: DocumentSnapshot


### PR DESCRIPTION
Change env to envs.

In the services section of the firestore database, the envs are saved in "envs". Now, the envs in installed_services are also saved in "envs" instead of "env".