### PR TITLE
Update the download process of a service to use the status field

### DIFF
--- a/src/installed_local_service.py
+++ b/src/installed_local_service.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+
+import logging
+import os
+import shutil
+import yaml
+
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+
+class InvalidLocalService(Exception):
+    """Local service is invalid."""
+
+class InvalidComposeContent(Exception):
+    """Compose information is invalid."""
+
+class WriteError(Exception):
+    """Error writing to file."""
+
+
+class InstalledLocalService:
+    """Class to handle the local functions of a installed service"""
+
+    service_name: str
+    """Name of the service"""
+    base_path: str
+    """Base path of the services"""
+    service_folder: str
+    """Folder of the service"""
+    compose_file_path: str
+    """Path of the service compose file"""
+    envs_file_path: str
+    """Path of the service envs file"""
+
+    def __init__(self, service_name: str, base_path: str) -> None:
+        self.service_name = service_name
+        self.base_path = base_path
+        self.service_folder = f"{base_path}/{service_name}"
+        self.compose_file_path = f"{self.service_folder}/docker-compose.yaml"
+        self.envs_file_path = f"{self.service_folder}/.env"
+
+    def get_version(self) -> str:
+        """Get the version of the service"""
+        logger.debug(f"Getting local version for '{self.service_name}' service")
+        try:
+            with open(self.compose_file_path, "r") as docker_compose_txt:
+                docker_compose = yaml.safe_load(docker_compose_txt)
+
+            local_version = docker_compose.get("services", {}).get(self.service_name, {}).get("labels", {}).get(
+                f"com.{self.service_name}.service.version", ""
+            )
+            if not local_version:
+                raise InvalidLocalService(f"Local '{self.compose_file_path}' file does not contain any version")
+            return local_version
+        except (FileNotFoundError, OSError, yaml.YAMLError):
+            raise InvalidLocalService(f"Local '{self.compose_file_path}' file could not be opened or read")
+        
+    def get_envs(self) -> Dict[str, Any]:
+        """Get the environment variables of the service"""
+        logger.debug(f"Getting local envs for '{self.service_name}' service")
+        try:
+            envs: Dict[str, Any] = {}
+            with open(self.envs_file_path, "r") as envs_txt:
+                lines = envs_txt.readlines()
+
+            for line in lines:
+                if "\n" in line:
+                    line = line[:-1]
+                key, value = line.split("=")
+                envs[key] = value
+            return envs
+        except (FileNotFoundError, OSError):
+            raise InvalidLocalService(f"Local '{self.envs_file_path}' file could not be opened or read")
+
+    def create_folder(self) -> None:
+        """Create the service folder in the local installation"""
+        logger.debug(f"Creating '{self.service_name}' service folder locally")
+        try:
+            os.mkdir(self.service_folder)
+        except FileExistsError:
+            logger.debug(f"Service {self.service_name} folder already exists")
+            return
+        logger.debug(f"'{self.service_name}' service folder has been locally created")
+        
+    def remove_service(self) -> None:
+        """Remove the service from the local installation"""
+        logger.debug(f"Removing '{self.service_name}' service locally")
+        try:
+            shutil.rmtree(self.service_folder)
+        except:
+            logger.debug(f"Service {self.service_name} was already removed locally")
+            return
+        logger.debug(f"'{self.service_name}' service has been locally removed")
+
+    def write_compose_file(self, compose_dict: Dict[str, Any]) -> None:
+        """Write the provided compose content to the local installation"""
+        logger.debug(f"Writing compose content to file for '{self.service_name}' service")
+        try:
+            compose_version = self._get_compose_dict_version(compose_dict)
+            with open(self.compose_file_path, "w") as compose_file:
+                yaml.dump(compose_dict, compose_file)
+        except (FileNotFoundError, OSError, yaml.YAMLError, InvalidComposeContent):
+            logger.error("Error writing to compose file")
+            raise WriteError(f"Local '{self.compose_file_path}' file could not be written")
+        logger.debug(f"Compose content for '{self.service_name}' ({compose_version}) service has been written")
+
+    def write_envs_file(self, envs_dict: Dict[str, Any]) -> None:
+        """Write the provided envs content to the local installation"""
+        logger.debug(f"Writing envs content to file for '{self.service_name}' service")
+        envs_list = [f"{key}={envs_dict[key]}\n" for key in envs_dict]
+        try:
+            with open(self.envs_file_path, "w") as envs_file:
+                envs_file.writelines(envs_list)
+        except (FileNotFoundError, OSError):
+            logger.error("Error writing to envs file")
+            raise WriteError(f"Local '{self.envs_file_path}' file could not be written")
+        logger.debug(f"Envs content for '{self.service_name}' service has been written")
+
+    def _get_compose_dict_version(self, compose_dict: Dict[str, Any]) -> str:
+        """Get the specific version of the compose dictionary """
+        logger.debug(f"Getting compose dict version")
+        version = (compose_dict.get("services", {})
+                            .get(self.service_name, {})
+                            .get("labels", {})
+                            .get(f"com.{self.service_name}.service.version", ""))
+        if not version:
+            logger.error(f"The compose content for '{self.service_name}' does not contain any version")
+            raise InvalidComposeContent(f"The compose content for '{self.service_name}' does not contain any version")
+        return version

--- a/src/installed_remote_service.py
+++ b/src/installed_remote_service.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+
+import logging
+
+from typing import Any, Dict, Optional
+from google.cloud.firestore import Client, DocumentReference, DocumentSnapshot
+
+logger = logging.getLogger(__name__)
+
+
+class UnconfiguredRemoteService(Exception):
+    """Remote service snapshot info is not configured."""
+
+
+class InvalidRemoteService(Exception):
+    """Remote service is invalid."""
+
+
+class EmptyDocumentSnapshot(DocumentSnapshot):
+    """Empty DocumentSnapshot class to avoid errors when testing."""
+    def __init__(self) -> None:
+        pass
+
+    def to_dict(self) -> Dict:
+        return {}
+
+
+class InstalledRemoteService:
+    """Class to handle the remote functions of a installed service"""
+
+    service_name: str
+    """Name of the service"""
+    device: DocumentReference
+    """Reference to the remote device"""
+    client: Client
+    """Firestore client"""
+    service_snapshot: DocumentSnapshot
+    """Snapshot of the remote service information"""
+    service_dict: Dict[str, Any]
+    """Dictionary of the remote service information"""
+
+    def __init__(self, service_name: str, device: DocumentReference, client: Client, service_snapshot: DocumentSnapshot = EmptyDocumentSnapshot()):
+        self.service_name = service_name
+        self.device = device
+        self.client = client
+        self.service_snapshot = service_snapshot
+        self.service_dict = self._get_service_dict()
+
+    def _get_service_dict(self) -> Dict[str, Any]:
+        service_dict = self.service_snapshot.to_dict()
+        if not service_dict:
+            return {}
+        return service_dict
+    
+    def get_version(self) -> str:
+        """Get the version of the service"""
+        logger.debug(f"Getting remote version for '{self.service_name}' service")
+        if not self.service_dict: raise UnconfiguredRemoteService(f"Service snapshot is not valid: {self.service_snapshot}")
+        if "version" not in self.service_dict: raise InvalidRemoteService(f"'version' key not found in service dict: {self.service_dict}")
+        return self.service_dict.get("version", "")
+    
+    def get_status(self) -> str:
+        """Get the status of the service"""
+        logger.debug(f"Getting remote status for '{self.service_name}' service")
+        if not self.service_dict: raise UnconfiguredRemoteService(f"Service snapshot is not valid: {self.service_snapshot}") 
+        if "status" not in self.service_dict: raise InvalidRemoteService(f"'status' key not found in service dict: {self.service_dict}")
+        return self.service_dict.get("status", "")
+    
+    def get_envs(self) -> Dict[str, Any]:
+        """Get the environment variables of the service"""
+        logger.debug(f"Getting remote envs for '{self.service_name}' service")
+        if not self.service_dict: raise UnconfiguredRemoteService(f"Service snapshot is not valid: {self.service_snapshot}")
+        if "envs" not in self.service_dict: raise InvalidRemoteService(f"'envs' key not found in service dict: {self.service_dict}")
+        return self.service_dict.get("envs", {})
+    
+    def get_marketplace_compose(self, version: Optional[str] = None) -> Dict[str, Any]:
+        """Get the docker compose file of the specific version from the marketplace"""
+        logger.debug(f"Getting remote compose file for '{self.service_name}' service")
+        try:
+            version = self.get_version() if not version else version
+        except (UnconfiguredRemoteService, InvalidRemoteService) as error:
+            raise error
+        
+        marketplace_service = self.client.document(f"services/{self.service_name}/versions/{version}").get().to_dict()
+        if not marketplace_service:
+            raise InvalidRemoteService(f"'{self.service_name}'->'{version}' service not found in the marketplace")
+        
+        return marketplace_service.get("compose", {})
+
+    def upload_service(self, local_version: str, local_envs: Dict[str, Any], status: str = "started") -> None:
+        """Upload the service info to the remote device"""
+        logger.debug(f"Uploading '{self.service_name}' ({local_version}) service to the remote device")
+        service_reference = self.device.collection("installed_services").document(self.service_name)
+        service_reference.set(
+            {"version": local_version,
+              "status": status,
+                "envs": local_envs}
+        )
+        logger.debug(f"'{self.service_name}' ({local_version}) service info uploaded to the remote device")
+
+    def update_service_status(self, service_status: str) -> None:
+        """Update the service status of the remote device."""
+        logger.debug(f"Updating '{self.service_name}' service status to {service_status} in remote device")
+        service_reference = self.device.collection("installed_services").document(
+            self.service_name
+        )
+        service_reference.update({"status": service_status})
+
+    def remove_service(self) -> None:
+        """Remove the service info from the remote device."""
+        logger.debug(f"Removing '{self.service_name}' service from Firebase")
+        service_reference = self.device.collection("installed_services").document(
+            self.service_name
+        )
+        service_reference.delete()

--- a/src/installed_service.py
+++ b/src/installed_service.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+
+import logging
+
+from installed_local_service import InstalledLocalService, InvalidLocalService, WriteError
+from installed_remote_service import InstalledRemoteService, UnconfiguredRemoteService, InvalidRemoteService
+
+logger = logging.getLogger(__name__)
+
+
+class InstallationFailed(Exception):
+    """Error installing the service."""
+
+class ReconfigurationFailed(Exception):
+    """Error reconfiguring the service."""
+
+class UpdateFailed(Exception):
+    """Error updating the service."""
+
+
+class InstalledService:
+    """Class to handle all the functions of a installed service, both local and remote
+    
+    This class requires a local service and a remote service
+    """
+
+    service_name: str
+    """Name of the service"""
+    local_service: InstalledLocalService
+    """Handler for the local functions of the installed service"""
+    remote_service: InstalledRemoteService
+    """Handler for the remote functions of the installed service"""
+
+    def __init__(self, service_name: str, local_service: InstalledLocalService, remote_service: InstalledRemoteService) -> None:
+        self.service_name = service_name
+        self.local_service = local_service
+        self.remote_service = remote_service
+
+    def are_services_equal(self) -> bool:
+        """Compare the versions of the local and remote services"""
+        logger.debug(f"Comparing versions for '{self.service_name}' service")
+        try:
+            local_version = self.local_service.get_version()
+            remote_version = self.remote_service.get_version()
+            if local_version != remote_version:
+                logger.warning("Local and remote versions are different")
+                return False
+            
+            local_envs = self.local_service.get_envs()
+            remote_envs = self.remote_service.get_envs()
+            if local_envs != remote_envs:
+                logger.warning("Local and remote envs are different")
+                return False
+            
+            return True
+        except (InvalidLocalService, UnconfiguredRemoteService, InvalidRemoteService) as error:
+            logger.error(f"Invalid local or remote service: {error}")
+            return False
+        
+    def upload_service(self) -> None:
+        """Upload the local service info to the remote service"""
+        logger.debug(f"Uploading '{self.service_name}' local service info to the remote service")
+        try:
+            version = self.local_service.get_version()
+            envs = self.local_service.get_envs()
+
+            self.remote_service.upload_service(version, envs)
+            logger.info(f"'{self.service_name}' service info has been succesfully uploaded")
+        except InvalidLocalService as error:
+            logger.error(f"The upload service function could not finish: {error}")
+       
+    def install_service(self) -> None:
+        """Install the service locally with the remote information"""
+        logger.debug(f"Installing '{self.service_name}' service locally")
+        self.local_service.create_folder()
+        try:
+            version = self.remote_service.get_version()
+            compose = self.remote_service.get_marketplace_compose()
+            envs = self.remote_service.get_envs()
+
+            self.local_service.write_compose_file(compose)
+            self.local_service.write_envs_file(envs)
+            logger.info(f"'{self.service_name}' ({version}) service has been succesfully installed")
+
+            self.remote_service.update_service_status("downloaded")
+        except (UnconfiguredRemoteService, InvalidRemoteService, WriteError) as error:
+            logger.error(f"The install service function could not finish: {error}")
+            self.remote_service.update_service_status("unknown")
+            raise InstallationFailed("Error installing the service")
+        
+    def reconfigure_service(self) -> None:
+        """Reconfigure the service locally with the remote information"""
+        logger.debug(f"Reconfiguring '{self.service_name}' service locally")
+        try:
+            envs = self.remote_service.get_envs()
+
+            self.local_service.write_envs_file(envs)
+            logger.info(f"'{self.service_name}' service has been succesfully reconfigured")
+
+            self.remote_service.update_service_status("reconfigured")
+        except (UnconfiguredRemoteService, InvalidRemoteService, WriteError) as error:
+            logger.error(f"The reconfigure service function could not finish: {error}")
+            self.remote_service.update_service_status("unknown")
+            raise ReconfigurationFailed("Error reconfiguring the service")
+        
+    def update_service(self) -> None:
+        """Update the service locally with the remote information"""
+        logger.debug(f"Updating '{self.service_name}' service locally")
+        try:
+            version = self.remote_service.get_version()
+            compose = self.remote_service.get_marketplace_compose()
+            envs = self.remote_service.get_envs()
+
+            self.local_service.write_compose_file(compose)
+            self.local_service.write_envs_file(envs)
+            logger.info(f"'{self.service_name}' ({version}) service has been succesfully updated")
+
+            self.remote_service.update_service_status("updated")
+        except (UnconfiguredRemoteService, InvalidRemoteService, WriteError) as error:
+            logger.error(f"The update service function could not finish: {error}")
+            self.remote_service.update_service_status("unknown")
+            raise UpdateFailed("Error updating the service")
+        
+    def remove_service(self) -> None:
+        """Remove the service locally and remotely"""
+        logger.debug(f"Removing '{self.service_name}' service completely")
+
+        self.local_service.remove_service()
+        self.remote_service.remove_service()
+        logger.info(f"'{self.service_name}' service has been completely removed")

--- a/src/installed_services_downloader.py
+++ b/src/installed_services_downloader.py
@@ -1,8 +1,10 @@
+#!/usr/bin/env python3
+
 import logging
 import os
 import shutil
 import threading
-from typing import Any, Dict, List, Optional, TypedDict
+from typing import Any, Dict, List, Optional
 
 import yaml
 from google.cloud.firestore_v1 import DocumentReference, DocumentSnapshot
@@ -12,16 +14,6 @@ from proto.datetime_helpers import DatetimeWithNanoseconds
 from firestore_client_handler import FirestoreClientHandler
 
 logger = logging.getLogger(__name__)
-
-
-class InstalledService(TypedDict):
-    """Dict representing the installed_services structure in firebase.
-
-    The structure of the document is `Dict[str, InstalledServices]`.
-    """
-
-    version: str
-    env: Dict[str, Any]
 
 
 class InvalidLocalService(Exception):
@@ -69,6 +61,7 @@ class InstalledServicesDownloader(FirestoreClientHandler):
         """Get the version of the local service given the service name.
         The local service is the one installed on the IoMBan device.
         """
+        logger.debug(f"Getting local version for '{service_name}' service")
         compose_path = f"{self.base_path}/{service_name}/docker-compose.yaml"
         try:
             with open(compose_path, "r") as docker_compose_txt:
@@ -79,21 +72,22 @@ class InstalledServicesDownloader(FirestoreClientHandler):
             ]
             return local_version
         except:
-            logger.warning(f"Invalid local serivce {service_name}")
+            logger.warning(f"Invalid local service {service_name}")
             raise InvalidLocalService
 
     def _get_remote_version(self, service_snapshot: DocumentSnapshot) -> str:
         """Get the version of the remote service given the services `DocumentSnapshot`.
         The remote service is the one in firebase.
         """
+        logger.debug("Getting remote version for the service")
         service_dict = service_snapshot.to_dict()
         if service_dict is None:
-            logger.warning(f"Invalid remote serivce {service_snapshot.id}")
+            logger.warning(f"Invalid remote service {service_snapshot.id}")
             raise InvalidRemoteService
 
         version = service_dict.get("version")
         if version is None:
-            logger.warning(f"Invalid remote serivce {service_snapshot.id}")
+            logger.warning(f"Invalid remote service: '{service_snapshot.id}'")
             raise InvalidRemoteService
 
         return version
@@ -104,6 +98,7 @@ class InstalledServicesDownloader(FirestoreClientHandler):
 
         If the local service or env is not found or the envs don't follow the given structure raise a `InvalidLocalService` error.
         """
+        logger.debug(f"Getting local env vars for '{service_name}' service")
         envs: Dict[str, Any] = {}
         env_path = f"{self.base_path}/{service_name}/.env"
         try:
@@ -117,7 +112,7 @@ class InstalledServicesDownloader(FirestoreClientHandler):
                 envs[key] = value
             return envs
         except:
-            logger.warning(f"Invalid remote serivce {service_name}")
+            logger.warning(f"Invalid local service: '{service_name}'")
             raise InvalidLocalService
 
     def _get_remote_envs(self, service_snapshot: DocumentSnapshot) -> Dict[str, Any]:
@@ -126,6 +121,7 @@ class InstalledServicesDownloader(FirestoreClientHandler):
 
         If the remote service has no fields or the fields don't have a env field raise a `InvalidRemoteService` error.
         """
+        logger.debug("Getting remote env vars for the service")
         service_dict = service_snapshot.to_dict()
         if service_dict is None:
             logger.warning(f"Invalid remote serivce {service_snapshot.id}")
@@ -144,6 +140,8 @@ class InstalledServicesDownloader(FirestoreClientHandler):
         """Get the docker compose of the remote service given the service name and `DocumentSnapshot`.
         The remote service is the one installed in firebase.
         """
+        logger.debug(
+            f"Getting remote compose file for '{service_name}' service")
         try:
             version = self._get_remote_version(service_snapshot)
         except InvalidRemoteService:
@@ -168,14 +166,15 @@ class InstalledServicesDownloader(FirestoreClientHandler):
         Read all the services on the `base_path`.
         For each service, if the service is on firebase, compare the services.
         Depending on the result of the comparison update the service or do nothing.
-        If the service is not in firebase, this mean that it was removed while the iombian was off, so remove the service from the iombian.
+        If the service is not in firebase, this mean that it was installed manually, so the information should be uploaded.
 
         If the service in firebase is not valid remove the service from the iombian.
         If the service in the iombian is not valid update the service.
         """
-        logger.debug("Syncing local and remote services")
+        logger.debug("Checking local and remote services")
         self.services = os.listdir(self.base_path)
         for service_name in self.services:
+            logger.debug(f"Checking the {service_name} service")
             service_snapshot = None
             if self.device:
                 service_reference = self.device.collection(
@@ -185,44 +184,37 @@ class InstalledServicesDownloader(FirestoreClientHandler):
 
             if service_snapshot and service_snapshot.exists:
                 try:
-                    logger.debug(service_name)
-                    logger.debug(service_snapshot)
                     if not self.compare(service_name, service_snapshot):
-                        self.remove_service(service_name)
-                        self.install_service(service_name, service_snapshot)
+                        self.remove_local_service(service_name)
+                        self.install_local_service(
+                            service_name, service_snapshot)
                     else:
                         logger.debug(f"Service {service_name} is up to date")
                 except InvalidRemoteService:
-                    self.remove_service(service_name)
+                    self.remove_local_service(service_name)
                     self.services.remove(service_name)
                 except InvalidLocalService:
-                    self.remove_service(service_name)
+                    self.remove_local_service(service_name)
                     try:
-                        self.install_service(service_name, service_snapshot)
+                        self.install_local_service(
+                            service_name, service_snapshot)
                     except:
                         self.services.remove(service_name)
 
             else:
-                self.remove_service(service_name)
+                logger.warning(
+                    f"'{service_name}' service not available in the remote server")
+                self.upload_remote_service(service_name)
+        logger.debug(f"Initial local and remote checking done")
 
     def start(self):
-        """Start the Installed Services Downloader by starting the listener, syncing with the remote and starting the firestore connection."""
-        logger.info("Installed Services Downloader started.")
+        """Start the Installed Services Downloader by initializing the client and waiting until the connection is ready."""
+        logger.debug("Installed Services Downloader started.")
         self.initialize_client()
-        self.device = (
-            self.client.collection("users")
-            .document(self.user_id)
-            .collection("devices")
-            .document(self.device_id)
-        )
-        self.read_local_services()
-        self.watch = self.device.collection("installed_services").on_snapshot(
-            self._on_installed_service_change
-        )
 
     def stop(self):
         """Stop the downloader by stopping the listener and the firestore connection."""
-        logger.info("Installed Services Downloader stopped.")
+        logger.debug("Installed Services Downloader stopped.")
         if self.watch is not None:
             self.watch.unsubscribe()
         self.device = None
@@ -233,19 +225,19 @@ class InstalledServicesDownloader(FirestoreClientHandler):
         self.stop()
         self.start()
 
-    def remove_service(self, service_name: str):
+    def remove_local_service(self, service_name: str):
         """Given the service name, remove the service from the IoMBian device."""
-        logger.debug(f"Removing {service_name} service")
+        logger.debug(f"Removing '{service_name}' service locally")
         service_path = f"{self.base_path}/{service_name}"
         try:
             shutil.rmtree(service_path)
         except:
-            logger.debug(f"Service {service_name} was already removed")
-            pass
+            logger.debug(f"Service {service_name} was already removed locally")
+        logger.info(f"'{service_name}' service has been locally removed")
 
-    def install_service(self, service_name: str, service_snapshot: DocumentSnapshot):
+    def install_local_service(self, service_name: str, service_snapshot: DocumentSnapshot):
         """Given the service name and `DocumentSnapshot`, install the service from firebase."""
-        logger.debug(f"Installing {service_name} Service")
+        logger.debug(f"Installing '{service_name}' service locally")
         compose = self._get_remote_compose(service_name, service_snapshot)
         envs_dict = self._get_remote_envs(service_snapshot)
 
@@ -263,29 +255,87 @@ class InstalledServicesDownloader(FirestoreClientHandler):
         envs_list = [f"{key}={envs_dict[key]}\n" for key in envs_dict]
         with open(f"{self.base_path}/{service_name}/.env", "w") as env_file:
             env_file.writelines(envs_list)
+        logger.info(f"'{service_name}' service has been locally installed")
+
+        self.update_remote_service_status(service_name, "downloaded")
+
+    def upload_remote_service(self, service_name: str):
+        """Given the service name, upload the local service info to firebase."""
+        logger.debug(f"Uploading '{service_name}' service info to Firebase")
+
+        local_service_version = self._get_local_version(service_name)
+        local_service_envs = self._get_local_envs(service_name)
+
+        service_reference = self.device.collection("installed_services").document(
+            service_name
+        )
+        service_reference.set(
+            {"version": local_service_version,
+                "envs": local_service_envs,
+                "status": "downloaded"}
+        )
+        logger.info(f"'{service_name}' service info uploaded to Firebase")
+
+    def remove_remote_service(self, service_name: str):
+        """Given the service name, remove the service from firebase."""
+        logger.debug(f"Removing '{service_name}' service from Firebase")
+        service_reference = self.device.collection("installed_services").document(
+            service_name
+        )
+        service_reference.delete()
+
+    def update_remote_service_status(self, service_name: str, service_status: str):
+        """Given the service name and a status, update the service status in firebase."""
+        logger.debug(
+            f"Updating '{service_name}' service status to {service_status} in Firebase")
+        service_reference = self.device.collection("installed_services").document(
+            service_name
+        )
+        service_reference.update({"status": service_status})
+
+    def is_remote_service_status_X(self, service_snapshot: DocumentSnapshot, status: str):
+        """Return `True` if the remote service status is X (the 'status' parameter)."""
+        service_dict = service_snapshot.to_dict()
+        service_status = service_dict.get("status")
+        if not service_status:
+            return False
+        return service_status == status
 
     def compare(self, service_name: str, service_snapshot: DocumentSnapshot):
-        """Return `True` if local and remote service are the same. If not return `False`."""
-        remote_version = self._get_remote_version(service_snapshot)
-        local_version = self._get_local_version(service_name)
-        logger.debug(f"Local version: {local_version}")
-        logger.debug(f"Remote version: {remote_version}")
-        if local_version != remote_version:
-            return False
+        """Return `True` if local and remote services are the same. If not return `False`."""
+        try:
+            remote_version = self._get_remote_version(service_snapshot)
+            local_version = self._get_local_version(service_name)
 
-        remote_envs = self._get_remote_envs(service_snapshot)
-        local_envs = self._get_local_envs(service_name)
-        logger.debug(f"Local envs: {local_envs}")
-        logger.debug(f"Remote envs: {remote_envs}")
-        return local_envs == remote_envs
+            if local_version != remote_version:
+                return False
+
+            remote_envs = self._get_remote_envs(service_snapshot)
+            local_envs = self._get_local_envs(service_name)
+
+            return local_envs == remote_envs
+        except (InvalidLocalService, InvalidRemoteService) as error:
+            logger.error(f"Invalid local or remote service: {error}")
+            return False
 
     def on_client_initialized(self):
         """Callback function when the client is initialized."""
         logger.debug("Firestore client initialized")
+        self.device = (
+            self.client.collection("users")
+            .document(self.user_id)
+            .collection("devices")
+            .document(self.device_id)
+        )
+        self.read_local_services()
+        self.watch = self.device.collection("installed_services").on_snapshot(
+            self._on_installed_service_change
+        )
 
     def on_server_not_responding(self):
         """Callback function when the server is not responding."""
         logger.error("Firestore server not responding")
+        threading.Timer(self.RESTART_DELAY_TIME_S, self.restart).start()
 
     def on_token_expired(self):
         """Callback function when the token is expired."""
@@ -298,34 +348,55 @@ class InstalledServicesDownloader(FirestoreClientHandler):
         changes: List[DocumentChange],
         read_time: DatetimeWithNanoseconds,
     ):
-        """For each change in the installed services update the local services in the iombian.
+        """For each change in the installed services collection, check the service status and react
+        accordingly.
 
-        There can be three type of changes:
-            - ADDED: install the service from firebase.
-            - REMOVED: remove the service from the iombian.
-            - MODIFIED: update the service by removing and installing it again.
+        Here is the list of the status values that should be handled:
+            - to-be-installed: the user has indicated that the service should be installed.
+            - to-be-updated: the user has changed the configuratior of the service (env vars)
+            - to-be-removed: the service is ready to be removed from Firebase.
         """
         for change in changes:
             service_snapshot = change.document
             service_name = service_snapshot.id
 
-            if change.type == ChangeType.ADDED:
-                if service_name not in self.services:
-                    try:
-                        self.install_service(service_name, service_snapshot)
-                        self.services.append(service_name)
-                    except InvalidRemoteService:
-                        pass
+            if change.type == ChangeType.REMOVED:
+                continue
 
-            elif change.type == ChangeType.REMOVED:
-                self.remove_service(service_name)
+            logger.debug(
+                f"Firebase notification received for {service_name} service")
+            if self.is_remote_service_status_X(service_snapshot, "to-be-installed"):
+                if service_name in self.services:
+                    self.update_remote_service_status(
+                        service_name, "downloaded")
+                    continue
+                try:
+                    self.install_local_service(service_name, service_snapshot)
+                    self.services.append(service_name)
+                except InvalidRemoteService:
+                    pass
+
+            elif self.is_remote_service_status_X(service_snapshot, "to-be-updated"):
+                self.install_local_service(service_name, service_snapshot)
+                if service_name not in self.services:
+                    self.services.append(service_name)
+
+            elif self.is_remote_service_status_X(service_snapshot, "to-be-removed"):
+                self.remove_local_service(service_name)
                 if service_name in self.services:
                     self.services.remove(service_name)
+                self.remove_remote_service(service_name)
 
-            elif change.type == ChangeType.MODIFIED:
-                self.remove_service(service_name)
+            else:
+                if self.compare(service_name, service_snapshot):
+                    logger.debug(
+                        f"Local and remote services are the same for '{service_name}'")
+                    continue
+                self.remove_local_service(service_name)
                 try:
-                    self.install_service(service_name, service_snapshot)
+                    self.install_local_service(service_name, service_snapshot)
+                    if service_name not in self.services:
+                        self.services.append(service_name)
                 except InvalidRemoteService:
                     if service_name in self.services:
                         self.services.remove(service_name)

--- a/src/installed_services_downloader.py
+++ b/src/installed_services_downloader.py
@@ -2,32 +2,25 @@
 
 import logging
 import os
-import shutil
 import threading
-from typing import Any, Dict, List, Optional
+from typing import Set, List, Optional
 
-import yaml
-from google.cloud.firestore_v1 import DocumentReference, DocumentSnapshot
+from google.cloud.firestore import DocumentReference, DocumentSnapshot
 from google.cloud.firestore_v1.watch import ChangeType, DocumentChange
 from proto.datetime_helpers import DatetimeWithNanoseconds
 
 from firestore_client_handler import FirestoreClientHandler
+from installed_service import InstalledService, InstallationFailed, ReconfigurationFailed, UpdateFailed
+from installed_remote_service import InstalledRemoteService
+from installed_local_service import InstalledLocalService
 
 logger = logging.getLogger(__name__)
-
-
-class InvalidLocalService(Exception):
-    """Local service is invalid."""
-
-
-class InvalidRemoteService(Exception):
-    """Remote service is invalid."""
 
 
 class InstalledServicesDownloader(FirestoreClientHandler):
     """Service that handles the installed services of the service and updates the local iombian services accordingly.
 
-    To start the service call `read_local_services()` and then `start()`.
+    To start the service call `start()`.
     """
 
     RESTART_DELAY_TIME_S = 0.5
@@ -38,10 +31,11 @@ class InstalledServicesDownloader(FirestoreClientHandler):
     """Id of the device."""
     device: Optional[DocumentReference]
     """Reference to the firestore document of this device."""
-    services: List[str]
+    services: Set[str]
     """The services in the local iombian."""
     base_path: str
     """The base path where the services are installed (normally "/opt/iombian-services")."""
+
 
     def __init__(
         self,
@@ -50,275 +44,63 @@ class InstalledServicesDownloader(FirestoreClientHandler):
         refresh_token: str,
         device_id: str,
         base_path: str,
-    ):
+    ) -> None:
         super().__init__(api_key, project_id, refresh_token)
         self.device_id = device_id
         self.device = None
-        self.services = []
+        self.services = set()
         self.base_path = base_path
+        self.subscription = None
 
-    def _get_local_version(self, service_name: str) -> str:
-        """Get the version of the local service given the service name.
-        The local service is the one installed on the IoMBan device.
-        """
-        logger.debug(f"Getting local version for '{service_name}' service")
-        compose_path = f"{self.base_path}/{service_name}/docker-compose.yaml"
-        try:
-            with open(compose_path, "r") as docker_compose_txt:
-                docker_compose = yaml.safe_load(docker_compose_txt)
-
-            local_version = docker_compose["services"][service_name]["labels"][
-                f"com.{service_name}.service.version"
-            ]
-            return local_version
-        except:
-            logger.warning(f"Invalid local service {service_name}")
-            raise InvalidLocalService
-
-    def _get_remote_version(self, service_snapshot: DocumentSnapshot) -> str:
-        """Get the version of the remote service given the services `DocumentSnapshot`.
-        The remote service is the one in firebase.
-        """
-        logger.debug("Getting remote version for the service")
-        service_dict = service_snapshot.to_dict()
-        if service_dict is None:
-            logger.warning(f"Invalid remote service {service_snapshot.id}")
-            raise InvalidRemoteService
-
-        version = service_dict.get("version")
-        if version is None:
-            logger.warning(f"Invalid remote service: '{service_snapshot.id}'")
-            raise InvalidRemoteService
-
-        return version
-
-    def _get_local_envs(self, service_name: str):
-        """Get the environment variables of the local service given the service name.
-        The local service is the one installed on the iombian.
-
-        If the local service or env is not found or the envs don't follow the given structure raise a `InvalidLocalService` error.
-        """
-        logger.debug(f"Getting local env vars for '{service_name}' service")
-        envs: Dict[str, Any] = {}
-        env_path = f"{self.base_path}/{service_name}/.env"
-        try:
-            with open(env_path, "r") as env_txt:
-                lines = env_txt.readlines()
-
-            for line in lines:
-                if "\n" in line:
-                    line = line[:-1]
-                key, value = line.split("=")
-                envs[key] = value
-            return envs
-        except:
-            logger.warning(f"Invalid local service: '{service_name}'")
-            raise InvalidLocalService
-
-    def _get_remote_envs(self, service_snapshot: DocumentSnapshot) -> Dict[str, Any]:
-        """Get the environment variables of the remote service given the services `DocumentSnapshot`.
-        The remote service is the one installed in firebase.
-
-        If the remote service has no fields or the fields don't have a env field raise a `InvalidRemoteService` error.
-        """
-        logger.debug("Getting remote env vars for the service")
-        service_dict = service_snapshot.to_dict()
-        if service_dict is None:
-            logger.warning(f"Invalid remote serivce {service_snapshot.id}")
-            raise InvalidRemoteService
-
-        envs = service_dict.get("envs")
-        if envs is None:
-            logger.warning(f"Invalid remote serivce {service_snapshot.id}")
-            raise InvalidRemoteService
-
-        return envs
-
-    def _get_remote_compose(
-        self, service_name: str, service_snapshot: DocumentSnapshot
-    ) -> Optional[Dict[str, Any]]:
-        """Get the docker compose of the remote service given the service name and `DocumentSnapshot`.
-        The remote service is the one installed in firebase.
-        """
-        logger.debug(
-            f"Getting remote compose file for '{service_name}' service")
-        try:
-            version = self._get_remote_version(service_snapshot)
-        except InvalidRemoteService:
-            return None
-
-        service_dict = (
-            self.client.collection("services")
-            .document(service_name)
-            .collection("versions")
-            .document(version)
-            .get()
-            .to_dict()
-        )
-        if service_dict is None:
-            return None
-
-        return service_dict.get("compose")
-
-    def read_local_services(self):
-        """Read the local services and compare them with the ones in firebase.
-
-        Read all the services on the `base_path`.
-        For each service, if the service is on firebase, compare the services.
-        Depending on the result of the comparison update the service or do nothing.
-        If the service is not in firebase, this mean that it was installed manually, so the information should be uploaded.
-
-        If the service in firebase is not valid remove the service from the iombian.
-        If the service in the iombian is not valid update the service.
-        """
-        logger.debug("Checking local and remote services")
-        self.services = os.listdir(self.base_path)
+    def _check_local_services(self) -> None:
+        """Read all the services on the `base_path` and process them individually."""
+        logger.debug("Checking all local services")
+        self.services = set(os.listdir(self.base_path))
         for service_name in self.services:
-            logger.debug(f"Checking the {service_name} service")
-            service_snapshot = None
-            if self.device:
-                service_reference = self.device.collection(
-                    "installed_services"
-                ).document(service_name)
-                service_snapshot = service_reference.get()
-
-            if service_snapshot and service_snapshot.exists:
-                try:
-                    if not self.compare(service_name, service_snapshot):
-                        self.remove_local_service(service_name)
-                        self.install_local_service(
-                            service_name, service_snapshot)
-                    else:
-                        logger.debug(f"Service {service_name} is up to date")
-                except InvalidRemoteService:
-                    self.remove_local_service(service_name)
-                    self.services.remove(service_name)
-                except InvalidLocalService:
-                    self.remove_local_service(service_name)
-                    try:
-                        self.install_local_service(
-                            service_name, service_snapshot)
-                    except:
-                        self.services.remove(service_name)
-
-            else:
-                logger.warning(
-                    f"'{service_name}' service not available in the remote server")
-                self.upload_remote_service(service_name)
+            self._check_local_service(service_name)
         logger.debug(f"Initial local and remote checking done")
 
-    def start(self):
+    def _check_local_service(self, service_name: str) -> None:
+        """Process the local service given the service name.
+        
+        For each service, if the service is in firebase, compare the services.
+        If the services are different, this means that the the device has been offline for some time.
+        If the service is not in firebase, this means that it was installed manually, so the information should be uploaded.
+        """
+        logger.debug(f"Processing '{service_name}' service")
+        service_snapshot: DocumentSnapshot = self.device.collection("installed_services").document(service_name).get()
+        installed_remote_service = InstalledRemoteService(service_name, self.device, self.client, service_snapshot)
+        installed_local_service = InstalledLocalService(service_name, self.base_path)
+        installed_service = InstalledService(service_name, installed_local_service, installed_remote_service)
+
+        if not service_snapshot or not service_snapshot.exists:
+            logger.warning(f"Service '{service_name}' not found in Firebase")
+            installed_service.upload_service()
+            return
+        
+        if not installed_service.are_services_equal():
+            logger.warning(f"Local and remote services are different for '{service_name}'. This must have happened because the device has been offline for some time.")
+            return
+
+    def start(self)  -> None:
         """Start the Installed Services Downloader by initializing the client and waiting until the connection is ready."""
         logger.debug("Installed Services Downloader started.")
         self.initialize_client()
 
-    def stop(self):
+    def stop(self) -> None:
         """Stop the downloader by stopping the listener and the firestore connection."""
         logger.debug("Installed Services Downloader stopped.")
-        if self.watch is not None:
-            self.watch.unsubscribe()
+        if self.subscription is not None:
+            self.subscription.unsubscribe()
         self.device = None
         self.stop_client()
 
-    def restart(self):
+    def restart(self) -> None:
         """Restart the Installed Services Downloader by calling `stop()` and `start()`."""
         self.stop()
         self.start()
 
-    def remove_local_service(self, service_name: str):
-        """Given the service name, remove the service from the IoMBian device."""
-        logger.debug(f"Removing '{service_name}' service locally")
-        service_path = f"{self.base_path}/{service_name}"
-        try:
-            shutil.rmtree(service_path)
-        except:
-            logger.debug(f"Service {service_name} was already removed locally")
-        logger.info(f"'{service_name}' service has been locally removed")
-
-    def install_local_service(self, service_name: str, service_snapshot: DocumentSnapshot):
-        """Given the service name and `DocumentSnapshot`, install the service from firebase."""
-        logger.debug(f"Installing '{service_name}' service locally")
-        compose = self._get_remote_compose(service_name, service_snapshot)
-        envs_dict = self._get_remote_envs(service_snapshot)
-
-        service_path = f"{self.base_path}/{service_name}"
-        try:
-            os.mkdir(service_path)
-        except FileExistsError:
-            pass
-
-        with open(
-            f"{self.base_path}/{service_name}/docker-compose.yaml", "w"
-        ) as compose_file:
-            yaml.dump(compose, compose_file)
-
-        envs_list = [f"{key}={envs_dict[key]}\n" for key in envs_dict]
-        with open(f"{self.base_path}/{service_name}/.env", "w") as env_file:
-            env_file.writelines(envs_list)
-        logger.info(f"'{service_name}' service has been locally installed")
-
-        self.update_remote_service_status(service_name, "downloaded")
-
-    def upload_remote_service(self, service_name: str):
-        """Given the service name, upload the local service info to firebase."""
-        logger.debug(f"Uploading '{service_name}' service info to Firebase")
-
-        local_service_version = self._get_local_version(service_name)
-        local_service_envs = self._get_local_envs(service_name)
-
-        service_reference = self.device.collection("installed_services").document(
-            service_name
-        )
-        service_reference.set(
-            {"version": local_service_version,
-                "envs": local_service_envs,
-                "status": "downloaded"}
-        )
-        logger.info(f"'{service_name}' service info uploaded to Firebase")
-
-    def remove_remote_service(self, service_name: str):
-        """Given the service name, remove the service from firebase."""
-        logger.debug(f"Removing '{service_name}' service from Firebase")
-        service_reference = self.device.collection("installed_services").document(
-            service_name
-        )
-        service_reference.delete()
-
-    def update_remote_service_status(self, service_name: str, service_status: str):
-        """Given the service name and a status, update the service status in firebase."""
-        logger.debug(
-            f"Updating '{service_name}' service status to {service_status} in Firebase")
-        service_reference = self.device.collection("installed_services").document(
-            service_name
-        )
-        service_reference.update({"status": service_status})
-
-    def is_remote_service_status_X(self, service_snapshot: DocumentSnapshot, status: str):
-        """Return `True` if the remote service status is X (the 'status' parameter)."""
-        service_dict = service_snapshot.to_dict()
-        service_status = service_dict.get("status")
-        if not service_status:
-            return False
-        return service_status == status
-
-    def compare(self, service_name: str, service_snapshot: DocumentSnapshot):
-        """Return `True` if local and remote services are the same. If not return `False`."""
-        try:
-            remote_version = self._get_remote_version(service_snapshot)
-            local_version = self._get_local_version(service_name)
-
-            if local_version != remote_version:
-                return False
-
-            remote_envs = self._get_remote_envs(service_snapshot)
-            local_envs = self._get_local_envs(service_name)
-
-            return local_envs == remote_envs
-        except (InvalidLocalService, InvalidRemoteService) as error:
-            logger.error(f"Invalid local or remote service: {error}")
-            return False
-
-    def on_client_initialized(self):
+    def on_client_initialized(self) -> None:
         """Callback function when the client is initialized."""
         logger.debug("Firestore client initialized")
         self.device = (
@@ -327,76 +109,75 @@ class InstalledServicesDownloader(FirestoreClientHandler):
             .collection("devices")
             .document(self.device_id)
         )
-        self.read_local_services()
-        self.watch = self.device.collection("installed_services").on_snapshot(
+        self._check_local_services()
+        self.subscription = self.device.collection("installed_services").on_snapshot(
             self._on_installed_service_change
         )
 
-    def on_server_not_responding(self):
+    def on_server_not_responding(self) -> None:
         """Callback function when the server is not responding."""
         logger.error("Firestore server not responding")
         threading.Timer(self.RESTART_DELAY_TIME_S, self.restart).start()
 
-    def on_token_expired(self):
+    def on_token_expired(self)-> None:
         """Callback function when the token is expired."""
         logger.debug("Refreshing Firebase client token id")
         threading.Timer(self.RESTART_DELAY_TIME_S, self.restart).start()
 
     def _on_installed_service_change(
         self,
-        snapshots: List[DocumentSnapshot],
+        _: List[DocumentSnapshot],
         changes: List[DocumentChange],
-        read_time: DatetimeWithNanoseconds,
-    ):
-        """For each change in the installed services collection, check the service status and react
-        accordingly.
+        __: DatetimeWithNanoseconds,
+    ) -> None:
+        """For each change in the installed services collection, check the service status and react accordingly.
 
         Here is the list of the status values that should be handled:
-            - to-be-installed: the user has indicated that the service should be installed.
-            - to-be-updated: the user has changed the configuratior of the service (env vars)
+            - to-be-installed: the user has requested that the service should be installed.
+            - to-be-reconfigured: the user has changed the configuration of the service (env vars).
+            - to-be-updated: the user has requested that the service version should be updated.
             - to-be-removed: the service is ready to be removed from Firebase.
         """
         for change in changes:
             service_snapshot = change.document
             service_name = service_snapshot.id
+            installed_remote_service = InstalledRemoteService(service_name, self.device, self.client, service_snapshot)
+            installed_local_service = InstalledLocalService(service_name, self.base_path)
+            service_status = installed_remote_service.get_status()
+            installed_service = InstalledService(service_name, installed_local_service, installed_remote_service)
 
             if change.type == ChangeType.REMOVED:
                 continue
 
-            logger.debug(
-                f"Firebase notification received for {service_name} service")
-            if self.is_remote_service_status_X(service_snapshot, "to-be-installed"):
+            logger.debug(f"Firebase notification received for '{service_name}' service ({service_status})")
+
+            if service_status == "to-be-installed":
                 if service_name in self.services:
-                    self.update_remote_service_status(
-                        service_name, "downloaded")
+                    installed_remote_service.update_service_status("ready")
                     continue
                 try:
-                    self.install_local_service(service_name, service_snapshot)
-                    self.services.append(service_name)
-                except InvalidRemoteService:
-                    pass
+                    installed_service.install_service()
+                    self.services.add(service_name)
+                except (InstallationFailed):
+                    logger.error(f"'{service_name}' service installation failed ('to-be-installed')")
 
-            elif self.is_remote_service_status_X(service_snapshot, "to-be-updated"):
-                self.install_local_service(service_name, service_snapshot)
-                if service_name not in self.services:
-                    self.services.append(service_name)
+            elif service_status == "to-be-reconfigured":
+                try:
+                    installed_service.reconfigure_service()
+                except (ReconfigurationFailed):
+                    logger.error(f"'{service_name}' service reconfiguration failed ('to-be-reconfigured')")
 
-            elif self.is_remote_service_status_X(service_snapshot, "to-be-removed"):
-                self.remove_local_service(service_name)
+            elif service_status == "to-be-updated":
+                try:
+                    installed_service.update_service()
+                except (UpdateFailed):
+                    logger.error(f"'{service_name}' service update failed ('to-be-updated')")
+
+            elif service_status == "to-be-removed":
+                installed_service.remove_service()
                 if service_name in self.services:
                     self.services.remove(service_name)
-                self.remove_remote_service(service_name)
 
-            else:
-                if self.compare(service_name, service_snapshot):
-                    logger.debug(
-                        f"Local and remote services are the same for '{service_name}'")
-                    continue
-                self.remove_local_service(service_name)
-                try:
-                    self.install_local_service(service_name, service_snapshot)
-                    if service_name not in self.services:
-                        self.services.append(service_name)
-                except InvalidRemoteService:
-                    if service_name in self.services:
-                        self.services.remove(service_name)
+            elif not installed_service.are_services_equal():
+                logger.error(f"Local and remote services are different for '{service_name}', this should not happen")
+ 

--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import logging
 import os
 import signal
@@ -17,12 +19,14 @@ logger = logging.getLogger(__name__)
 
 
 def signal_handler(sig, frame):
-    logger.warn("Stopping the service")
+    logger.info("Stopping IoMBian Installed Services Downloader Service")
     comm_module.stop()
     installed_services_downloader.stop()
 
 
 if __name__ == "__main__":
+    logger.info("Starting IoMBian Installed Services Downloader Service")
+
     comm_module = CommunicationModule(host=CONFIG_HOST, port=CONFIG_PORT)
     comm_module.start()
 

--- a/src/main.py
+++ b/src/main.py
@@ -7,7 +7,7 @@ import signal
 from communication_module import CommunicationModule
 from installed_services_downloader import InstalledServicesDownloader
 
-LOG_LEVEL = os.environ.get("LOG_LEVEL", logging.INFO)
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")
 CONFIG_HOST = os.environ.get("CONFIG_HOST", "127.0.0.1")
 CONFIG_PORT = int(os.environ.get("CONFIG_PORT", 5555))
 BASE_PATH = os.environ.get("BASE_PATH", "/opt/iombian-services")


### PR DESCRIPTION
The service now handles the following status:
- **to-be-installed**: writes the service configuration available in Firebase (docker-compose.yaml and .env files) in the local folder
- **to-be-reconfigured**: overwrites the service configuration available in Firebase (docker-compose.yaml and .env files) in the local folder 
- **to-be-updated**: overwrites the service configuration available in Firebase (docker-compose.yaml and .env files) in the local folder 
- **to-be-removed**: removes the service document in Firebase

A new "**InstalledService**" class has been introduced, with the corresponding **InstalledLocalService** and **InstalledRemoteService** classes, in order to improve code readability and to group methods according to their scope of responsibility. The InstalledLocalService class only handles the local folder functions, while InstalledRemoteService class handles the Firebase related functions.

Signed-off-by: Aitor Iturrioz <aiturrioz@tknika.eus>